### PR TITLE
[Changed] fetch all tags before tag removal

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -63,6 +63,7 @@ else
   exit 1
 fi
 
+ git fetch --all --tags
  git fetch --prune --prune-tags
  tags_to_remove=$(git tag --sort=-creatordate | tail -n +31)
  if [ -z "$tags_to_remove" ]


### PR DESCRIPTION
Fetch all tags before tag removal. Im trying to fix this script not removing the old tags.

I'll see if this works when deploying a feature in BGs.